### PR TITLE
include entity keyword and db spec in contract for persisted predicate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,10 +552,10 @@ Subsequently, to save a row-map the update-fn will be used instead of
 insert-fn. This mechanism is fine for auto-generated keys, but becomes
 an obstacle if you want to handle in the id value by yourself.
 
-Therefore the er-config options may contain a key `:persisted-pred-fn`
-that points to a function `(fn [id-kw row-map])` that returns true,
-if the row-map has a corresponding record in the database. The default
-value is `agg/persisted?`.
+Therefore the er-config options may contain a key `:persisted-pred-fn` that
+points to a function `(fn [id-kw row-map entity-kw db-spec])` that returns true,
+if the row-map has a corresponding record in the database. The default value is
+`agg/persisted?`.
 
 Alternative implementations for `:persisted-pred-fn` might use an
 additional DB lookup or use a special key to mark a row-map as

--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ insert-fn. This mechanism is fine for auto-generated keys, but becomes
 an obstacle if you want to handle in the id value by yourself.
 
 Therefore the er-config options may contain a key `:persisted-pred-fn` that
-points to a function `(fn [id-kw row-map entity-kw db-spec])` that returns true,
+points to a function `(fn [db-spec entity-kw id-kw row-map])` that returns true,
 if the row-map has a corresponding record in the database. The default value is
 `agg/persisted?`.
 


### PR DESCRIPTION
It's useful to have some more context in the function value you can provide for `:persisted-pred-fn`, such as the entity that needs to be queried for existence, and the DB spec that can be used to perform an actual query.

Not sure if this is the best way to do it, as it involves an API break, was just the simplest way.
